### PR TITLE
Fix default case label in crossfire affinity pattern

### DIFF
--- a/src/environment/environment_linux.cc
+++ b/src/environment/environment_linux.cc
@@ -140,7 +140,7 @@ Status LinuxEnvironment::SetThreadAffinity(pthread_t thread, uint64_t core,
       case 21: core = 15; break;
       case 22: core = 19; break;
       case 23: core = 23; break;
-      defautl: RAW_CHECK(false, "wrong core"); break;
+      default: RAW_CHECK(false, "wrong core"); break;
     }
   } else if(affinity_pattern == 5) {
     // spread on c153


### PR DESCRIPTION
Small bug fix. The default case label has a typo, which makes it a generic label, and not the actual default case for the switch. The current code falls through for unexpected values of core.