### PR TITLE
Fix target address to be persisted

### DIFF
--- a/src/mwcas/mwcas.h
+++ b/src/mwcas/mwcas.h
@@ -169,7 +169,7 @@ public:
 #ifdef PMEM
     /// Persist the content of address_
     inline void PersistAddress() {
-      NVRAM::Flush(sizeof(uint64_t*), (void*)&address_);
+      NVRAM::Flush(sizeof(uint64_t*), (void*)address_);
     }
 #endif
 


### PR DESCRIPTION
It's just a small fix. This fix correctly persists the contents of `address_`.